### PR TITLE
docs: fixed CRD link

### DIFF
--- a/policy-report/README.md
+++ b/policy-report/README.md
@@ -11,7 +11,7 @@ See the [proposal](https://docs.google.com/document/d/1nICYLkYS1RE3gJzuHOfHeAC25
 Add the CRDs to your cluster:
 
 ```console
-kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/policy.kubernetes.io_policyreports.yaml
+kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/wgpolicyk8s.io_policyreports.yaml
 ```
 
 Create a sample policy report resource:


### PR DESCRIPTION
Fix for #28 

The [Installing Guide](https://github.com/kubernetes-sigs/wg-policy-prototypes/tree/master/policy-report#installing) pointed to a file which didn't exist for adding the CRDs. I've replaced that with the link to the [correct file](https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/master/policy-report/crd/wgpolicyk8s.io_policyreports.yaml). Please let me know if some other file is to be used here. Thanks!