### PR TITLE
Change version of controller-gen to 0.2.6

### DIFF
--- a/policy-report/Makefile
+++ b/policy-report/Makefile
@@ -36,7 +36,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.6 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen


### PR DESCRIPTION
The controller-gen had different versioning in `Makefile` and `crd/wgpolicyk8s.io_policyreports.yaml` which caused the version in the later to be changed to 0.2.5.

Fixes #32 