### PR TITLE
fix(sample-resource): fixed erros in sample policy report resource

### DIFF
--- a/policy-report/samples/sample-cis-k8s.yaml
+++ b/policy-report/samples/sample-cis-k8s.yaml
@@ -1,9 +1,9 @@
-apiVersion: policy.kubernetes.io/v1alpha1
+apiVersion: wgpolicyk8s.io/v1alpha1
 kind: PolicyReport
 metadata:
   name: sample-cis-bench-api-server
   labels:
-    policy.kubernetes.io/engine: kube-cis
+    wgpolicyk8s.io/engine: kube-cis
   annotations:
     name: CIS Kubernetes Benchmarks
     category: API Server
@@ -18,23 +18,22 @@ summary:
 results:
   - policy: api-server:anonymous-auth
     message: ensure that --anonymous-auth argument is set to false
-    status: Warn
+    status: warn
     scored: true
     data:
       category: API Server
-      index:  1.2.1
+      index: 1.2.1
   - policy: api-server:basic-auth-file
     message: ensure that --basic-auth-file argument is not set
-    status: Fail
+    status: fail
     scored: true
     data:
       category: API Server
-      index:  1.2.2
+      index: 1.2.2
   - policy: api-server:token-auth-file
     message: ensure that --token-auth-file argument is not set
-    status: Warn
+    status: warn
     scored: false
     data:
       category: API Server
-      index:  1.2.2
-
+      index: 1.2.2


### PR DESCRIPTION
Fix for #31 

The api version was incorrect in the [sample policy resource](https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/master/policy-report/samples/sample-cis-k8s.yaml#L1). Apart from that there were some errors due to using the wrong casing for result status values which I've also fixed. I've tested locally and now following the guide works and we are able to view policy report resources:
![working](https://user-images.githubusercontent.com/56963264/105964601-71813f00-60a8-11eb-981a-f006f6514766.png)

Please let me know in case something needs to be changed in this fix. Thanks!