### PR TITLE
create a sample policy report from falco alerts

### DIFF
--- a/policy-report/samples/sample-falco-policy.yaml
+++ b/policy-report/samples/sample-falco-policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: wgpolicyk8s.io/v1alpha2
+kind: PolicyReport
+metadata:
+  name: falco-alerts-policy
+  namespace: my-namespace
+  labels:
+    policy.kubernetes.io/engine: falco-agent
+summary:
+  fail: 1
+results:
+- policy: "Change thread namespace"
+  message: "Falco alert created due to the Change thread namespace rule"
+  result: fail
+  scored: false
+  resources:
+    - apiVersion: v1
+      kind: Pod
+      name: a-pod
+      namespace: my-namespace
+  properties:
+    details: '12:57:37.086240437: Notice Namespace change (setns) by unexpected program (user=root user_loginuid=-1 command=ovnkube --init-node ...'
+    container.id: "0f8d7e2a3296"
+    evt.arg.path: "/bin/directory-created-by-event-generator"
+    proc.cmdline: "event-generator run --loop ^syscall"
+    severity: low
+---
+apiVersion: wgpolicyk8s.io/v1alpha2
+kind: ClusterPolicyReport
+metadata:
+  name: falco-alerts-policy
+  labels:
+    policy.kubernetes.io/engine: falco-agent
+summary:
+  fail: 1
+results:
+- policy: audit
+  message: "audit rule violation from the kubernetes api server"
+  result: fail
+  scored: false
+  properties:
+    details: 'Warning K8s Operation performed by user not in allowed list of users'
+    severity: medium
+    user: username
+    target: kubernetes/endpoints
+    verb: create
+    uri: '/api/v1/namespaces/default/endpoints/kubernetes'
+    resp: '200'


### PR DESCRIPTION
The attached PR is a sample PolicyReport that could be created from Falco alerts.  

To understand how the PolicyReport was calculated, here are the falco alerts used to create the samples.

```
{
  "output": "19:27:27.180629284: Notice Namespace change (setns) by unexpected program (user=root user_loginuid=-1 command=ovnkube --init-node host.compute.internal --nb-address ssl:10.0.135.10:9641,ssl:10.0.175.156:9641,ssl:10.0.213.248:9641 --sb-address ssl:10.0.135.10:9642,ssl:10.0.175.156:9642,ssl:10.0.213.248:9642 --nb-client-privkey /ovn-cert/tls.key --nb-client-cert /ovn-cert/tls.crt --nb-client-cacert /ovn-ca/ca-bundle.crt --nb-cert-common-name ovn --sb-client-privkey /ovn-cert/tls.key --sb-client-cert /ovn-cert/tls.crt --sb-client-cacert /ovn-ca/ca-bundle.crt --sb-cert-common-name ovn --config-file=/run/ovnkube-config/ovnkube.conf --loglevel 4 --inactivity-probe=30000 --gateway-mode local --gateway-interface br-ex --metrics-bind-address 127.0.0.1:29103 parent=conmon k8s.ns=openshift-ovn-kubernetes k8s.pod=ovnkube-node-ht59t container=8bba55a01218 container_id=8bba55a01218 image=<NA>:<NA>) k8s.ns=openshift-ovn-kubernetes k8s.pod=ovnkube-node-ht59t container=8bba55a01218 k8s.ns=openshift-ovn-kubernetes k8s.pod=ovnkube-node-ht59t container=8bba55a01218 k8s.ns=openshift-ovn-kubernetes k8s.pod=ovnkube-node-ht59t container=8bba55a01218",
  "priority": "Notice",
  "rule": "Change thread namespace",
  "time": "2021-05-25T19:27:27.180629284Z",
  "output_fields": {
    "container.id": "8bba55a01218",
    "container.image.repository": null,
    "container.image.tag": null,
    "evt.time": 1621970847180629200,
    "k8s.ns.name": "openshift-ovn-kubernetes",
    "k8s.pod.name": "ovnkube-node-ht59t",
    "proc.cmdline": "ovnkube --init-node hostname.compute.internal --nb-address ssl:10.0.135.10:9641,ssl:10.0.175.156:9641,ssl:10.0.213.248:9641 --sb-address ssl:10.0.135.10:9642,ssl:10.0.175.156:9642,ssl:10.0.213.248:9642 --nb-client-privkey /ovn-cert/tls.key --nb-client-cert /ovn-cert/tls.crt --nb-client-cacert /ovn-ca/ca-bundle.crt --nb-cert-common-name ovn --sb-client-privkey /ovn-cert/tls.key --sb-client-cert /ovn-cert/tls.crt --sb-client-cacert /ovn-ca/ca-bundle.crt --sb-cert-common-name ovn --config-file=/run/ovnkube-config/ovnkube.conf --loglevel 4 --inactivity-probe=30000 --gateway-mode local --gateway-interface br-ex --metrics-bind-address 127.0.0.1:29103",
    "proc.pname": "conmon",
    "user.loginuid": -1,
    "user.name": "root"
  }
}
```

An audit event from falco:
```
14:37:53.789945088: Warning K8s Operation performed by user not in allowed list of users (user=username target=kubernetes/endpoints verb=create uri=/api/v1/namespaces/default/endpoints/kubernetes resp=200)
```

Signed-off-by: Gus Parvin <gparvin@redhat.com>