### PR TITLE
[FIX]: adds and fixes namespaces for kube-bench job to be specified by user

### DIFF
--- a/policy-report/kube-bench-adapter/README.md
+++ b/policy-report/kube-bench-adapter/README.md
@@ -47,7 +47,8 @@ kubectl get clusterpolicyreports
 ###### Command Line Arguments
 |      Argument         |  Type   |    Default value         | Allowed value  | Usage                                            |
 |:--------------------- |:-------:|-------------------------:|:--------------:|:------------------------------------------------:|
-| -category             | `string`| CIS Benchmarks           |   Any string name valid for category             | category of the policy report                    |   
+| -category             | `string`| CIS Benchmarks           |   Any string name valid for category             | category of the policy report 
+| -namespace            | `string`| default                   |  any string name for required namespace |  specifies namespace where kube-bench job will run
 | -kube-bench-benchmark | `string`|   cis-1.6                    |    cis-1.5, cis-1.6, gke-1.0, eks-1.0, ack-1.0            | specify the benchmark for kube-bench job         |
 | -kube-bench-targets   | `string`(accepts multiple values)| master,node,etcd,policies| 	master, controlplane, node, etcd, policies               | targets for benchmark of kube-bench job          |   
 | -kube-bench-version   | `string`|    1.21                    |   Kubernetes Version like 1.20,1.21,etc             | specify the Kubernetes version for kube-bench job|

--- a/policy-report/kube-bench-adapter/pkg/params/args.go
+++ b/policy-report/kube-bench-adapter/pkg/params/args.go
@@ -7,6 +7,7 @@ import (
 type KubeBenchArgs struct {
 	Name               string
 	Category           string
+	Namespace          string
 	Kubeconfig         string
 	KubebenchYAML      string
 	KubebenchImg       string

--- a/policy-report/kube-bench-adapter/pkg/params/parse.go
+++ b/policy-report/kube-bench-adapter/pkg/params/parse.go
@@ -15,6 +15,7 @@ var (
 func ParseArguments() {
 	flag.StringVar(&Params.Name, "name", "kube-bench", "name of policy report")
 	flag.StringVar(&Params.Category, "category", "CIS Benchmarks", "category of the policy report")
+	flag.StringVar(&Params.Namespace, "namespace", "default", "namespace of kube-bench job")
 	flag.StringVar(&Params.KubebenchYAML, "yaml", "job.yaml", "YAML for kube-bench job")
 	flag.StringVar(&Params.KubebenchTargets, "kube-bench-targets", "master,node,etcd,policies", "targets for benchmark of kube-bench job")
 	flag.StringVar(&Params.KubebenchVersion, "kube-bench-version", "", "specify the Kubernetes version for kube-bench job")


### PR DESCRIPTION
This PR fixes #93 

It adds `--namespace` option for user to specify in which the kube-bench job must be run.

cc @realshuting @JimBugwadia 

Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>