### PR TITLE
[FIX]: adds timestamp to kube-bench adapter

### DIFF
--- a/policy-report/kube-bench-adapter/pkg/report/create.go
+++ b/policy-report/kube-bench-adapter/pkg/report/create.go
@@ -3,6 +3,7 @@ package report
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -47,6 +48,7 @@ func newResult(category string, control *kubebench.Controls, group *kubebench.Gr
 		Result:      convertState(check.State),
 		Scored:      check.Scored,
 		Description: check.Text,
+		Timestamp:   metav1.Timestamp{Seconds: int64(time.Now().Second()), Nanos: int32(time.Now().Nanosecond())},
 		Properties: map[string]string{
 			"index":           check.ID,
 			"audit":           check.Audit,

--- a/policy-report/kube-bench-adapter/pkg/report/write.go
+++ b/policy-report/kube-bench-adapter/pkg/report/write.go
@@ -7,13 +7,13 @@ import (
 
 	clusterpolicyreport "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 
-	client "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/generated/v1alpha2/clientset/versioned"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
+	client "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/generated/v1alpha2/clientset/versioned"
 )
 
 func Write(r *clusterpolicyreport.ClusterPolicyReport, kubeconfigPath string) (*clusterpolicyreport.ClusterPolicyReport, error) {


### PR DESCRIPTION
This PR adds timestamp to kube-bench adapter and fixes #100 
Since kube-bench itself doesn't have timestamp field, we couldn't earlier map it, that's why for now,
we are mapping it with `time.Now`

The updated clusterpolicyreport somewhat will look like this:
```yaml
 - category: CIS Benchmarks
    message: Ensure that the admin.conf file permissions are set to 644 or more restrictive
      (Automated)
    policy: Master Node Security Configuration 1.1.13
    properties:
      AuditConfig: ""
      AuditEnv: ""
      IsMultiple: "false"
      actual_value: permissions=600
      audit: /bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a
        /etc/kubernetes/admin.conf; fi'
      expected_result: permissions has permissions 600, expected 644 or more restrictive
      index: 1.1.13
      reason: ""
      remediation: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chmod 644 /etc/kubernetes/admin.conf
      test_info: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chmod 644 /etc/kubernetes/admin.conf
      type: ""
    result: pass
    rule: Master Node Configuration Files
    scored: true
    source: Kube Bench
    timestamp:
      nanos: 585075739
      seconds: 36
  - category: CIS Benchmarks
    message: Ensure that the admin.conf file ownership is set to root:root (Automated)
    policy: Master Node Security Configuration 1.1.14
    properties:
      AuditConfig: ""
      AuditEnv: ""
      IsMultiple: "false"
      actual_value: root:root
      audit: /bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G
        /etc/kubernetes/admin.conf; fi'
      expected_result: '''root:root'' is present'
      index: 1.1.14
      reason: ""
      remediation: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chown root:root /etc/kubernetes/admin.conf
      test_info: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chown root:root /etc/kubernetes/admin.conf
      type: ""
    result: pass
    rule: Master Node Configuration Files
    scored: true
    source: Kube Bench
    timestamp:
      nanos: 585076620
      seconds: 36
```

Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>

cc @JimBugwadia @realshuting 