### PR TITLE
[FIX]: changes policy and rule to be more focussed name in kube-bench-adapter

### DIFF
--- a/policy-report/kube-bench-adapter/pkg/report/create.go
+++ b/policy-report/kube-bench-adapter/pkg/report/create.go
@@ -41,7 +41,7 @@ func New(cisResults *kubebench.OverallControls, name string, category string) (*
 
 func newResult(category string, control *kubebench.Controls, group *kubebench.Group, check *kubebench.Check) *clusterpolicyreport.PolicyReportResult {
 	return &clusterpolicyreport.PolicyReportResult{
-		Policy:      control.Text,
+		Policy:      control.Text + " " + check.ID,
 		Rule:        group.Text,
 		Source:      PolicyReportSource,
 		Category:    category,

--- a/policy-report/kube-bench-adapter/pkg/report/create.go
+++ b/policy-report/kube-bench-adapter/pkg/report/create.go
@@ -41,7 +41,7 @@ func New(cisResults *kubebench.OverallControls, name string, category string) (*
 
 func newResult(category string, control *kubebench.Controls, group *kubebench.Group, check *kubebench.Check) *clusterpolicyreport.PolicyReportResult {
 	return &clusterpolicyreport.PolicyReportResult{
-		Policy:      check.ID + " " + control.Text,
+		Policy:      check.ID + "-" + control.Text,
 		Rule:        group.Text,
 		Source:      PolicyReportSource,
 		Category:    category,

--- a/policy-report/kube-bench-adapter/pkg/report/create.go
+++ b/policy-report/kube-bench-adapter/pkg/report/create.go
@@ -41,7 +41,7 @@ func New(cisResults *kubebench.OverallControls, name string, category string) (*
 
 func newResult(category string, control *kubebench.Controls, group *kubebench.Group, check *kubebench.Check) *clusterpolicyreport.PolicyReportResult {
 	return &clusterpolicyreport.PolicyReportResult{
-		Policy:      control.Text + " " + check.ID,
+		Policy:      check.ID + " " + control.Text,
 		Rule:        group.Text,
 		Source:      PolicyReportSource,
 		Category:    category,


### PR DESCRIPTION
This PR aims to fix #101 by making `policy` and `rule` having more focused names in kube-bench-adapter

(Note: for now it changed just `policy` name, little more confirmation required for `rule` mapping)

The updated policy would like:

```yaml
 - category: CIS Benchmarks
    message: Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
    policy: 1.1.12  Master Node Security Configuration 
    properties:
      AuditConfig: ""
      AuditEnv: ""
      IsMultiple: "false"
      actual_value: root:root
      audit: ps -ef | grep etcd | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'
        | xargs stat -c %U:%G
      expected_result: '''etcd:etcd'' is present'
      index: 1.1.12
      reason: ""
      remediation: |
        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
        from the below command:
        ps -ef | grep etcd
        Run the below command (based on the etcd data directory found above).
        For example, chown etcd:etcd /var/lib/etcd
      test_info: |
        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
        from the below command:
        ps -ef | grep etcd
        Run the below command (based on the etcd data directory found above).
        For example, chown etcd:etcd /var/lib/etcd
      type: ""
    result: fail
    rule: Master Node Configuration Files
    scored: true
    source: Kube Bench
    timestamp:
      nanos: 585074788
      seconds: 36
  - category: CIS Benchmarks
    message: Ensure that the admin.conf file permissions are set to 644 or more restrictive
      (Automated)
    policy: 1.1.13 Master Node Security Configuration 
    properties:
      AuditConfig: ""
      AuditEnv: ""
      IsMultiple: "false"
      actual_value: permissions=600
      audit: /bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a
        /etc/kubernetes/admin.conf; fi'
      expected_result: permissions has permissions 600, expected 644 or more restrictive
      index: 1.1.13
      reason: ""
      remediation: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chmod 644 /etc/kubernetes/admin.conf
      test_info: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chmod 644 /etc/kubernetes/admin.conf
      type: ""
    result: pass
    rule: Master Node Configuration Files
    scored: true
    source: Kube Bench
    timestamp:
      nanos: 585075739
      seconds: 36
  - category: CIS Benchmarks
    message: Ensure that the admin.conf file ownership is set to root:root (Automated)
    policy: 1.1.14  Master Node Security Configuration 
    properties:
      AuditConfig: ""
      AuditEnv: ""
      IsMultiple: "false"
      actual_value: root:root
      audit: /bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G
        /etc/kubernetes/admin.conf; fi'
      expected_result: '''root:root'' is present'
      index: 1.1.14
      reason: ""
      remediation: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chown root:root /etc/kubernetes/admin.conf
      test_info: |
        Run the below command (based on the file location on your system) on the master node.
        For example,
        chown root:root /etc/kubernetes/admin.conf
      type: ""
    result: pass
    rule: Master Node Configuration Files
    scored: true
    source: Kube Bench
    timestamp:
      nanos: 585076620
      seconds: 36
   ```
   
Note: The above policy also shows the changes that #103 will fix (that is timestamp)

Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>

cc @JimBugwadia @realshuting 