### PR TITLE
Extend PolicyReportResult severity for better mapping with common tools

### DIFF
--- a/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -153,9 +153,11 @@ spec:
                 severity:
                   description: Severity indicates policy check result criticality
                   enum:
+                  - critical
                   - high
                   - low
                   - medium
+                  - info
                   type: string
                 source:
                   description: Source is an identifier for the policy engine that manages this report

--- a/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
+++ b/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
@@ -153,9 +153,11 @@ spec:
                 severity:
                   description: Severity indicates policy check result criticality
                   enum:
+                  - critical
                   - high
                   - low
                   - medium
+                  - info
                   type: string
                 source:
                   description: Source is an identifier for the policy engine that manages this report


### PR DESCRIPTION
Many common tools like Falco or Trivy having more fine-grained option for severity level. Because the PolicyReport CRD supports only 3 levels, it is harder to map between them. 

To make this easier I would like to add two new levels to the related enum.

Signed-off-by: Frank Jogeleit <frank.jogeleit@web.de>