### PR TITLE
Update go field name in v1beta1 api

### DIFF
--- a/policy-report/crd/v1beta1/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/policy-report/crd/v1beta1/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -737,9 +737,9 @@ spec:
                     policy rule
                   type: object
                 resourceSelector:
-                  description: SubjectSelector is an optional label selector for checked
-                    Kubernetes resources. For example, a policy result may apply to
-                    all pods that match a label. Either a Subject or a SubjectSelector
+                  description: ResourceSelector is an optional label selector for
+                    checked Kubernetes resources. For example, a policy result may
+                    apply to all pods that match a label. Either a Subject or a ResourceSelector
                     can be specified. If neither are provided, the result is assumed
                     to be for the policy report scope.
                   properties:

--- a/policy-report/crd/v1beta1/wgpolicyk8s.io_policyreports.yaml
+++ b/policy-report/crd/v1beta1/wgpolicyk8s.io_policyreports.yaml
@@ -734,9 +734,9 @@ spec:
                     policy rule
                   type: object
                 resourceSelector:
-                  description: SubjectSelector is an optional label selector for checked
-                    Kubernetes resources. For example, a policy result may apply to
-                    all pods that match a label. Either a Subject or a SubjectSelector
+                  description: ResourceSelector is an optional label selector for
+                    checked Kubernetes resources. For example, a policy result may
+                    apply to all pods that match a label. Either a Subject or a ResourceSelector
                     can be specified. If neither are provided, the result is assumed
                     to be for the policy report scope.
                   properties:

--- a/policy-report/docs/index.html
+++ b/policy-report/docs/index.html
@@ -350,9 +350,9 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <em>(Optional)</em>
-SubjectSelector is an optional label selector for checked Kubernetes resources.
+ResourceSelector is an optional label selector for checked Kubernetes resources.
 For example, a policy result may apply to all pods that match a label.
-Either a Subject or a SubjectSelector can be specified. If neither are provided, the
+Either a Subject or a ResourceSelector can be specified. If neither are provided, the
 result is assumed to be for the policy report scope.
 </td>
 </tr>

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/policyreport_types.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/policyreport_types.go
@@ -100,12 +100,12 @@ type PolicyReportResult struct {
 	// +optional
 	Subjects []*corev1.ObjectReference `json:"resources,omitempty"`
 
-	// SubjectSelector is an optional label selector for checked Kubernetes resources.
+	// ResourceSelector is an optional label selector for checked Kubernetes resources.
 	// For example, a policy result may apply to all pods that match a label.
-	// Either a Subject or a SubjectSelector can be specified. If neither are provided, the
+	// Either a Subject or a ResourceSelector can be specified. If neither are provided, the
 	// result is assumed to be for the policy report scope.
 	// +optional
-	SubjectSelector *metav1.LabelSelector `json:"resourceSelector,omitempty"`
+	ResourceSelector *metav1.LabelSelector `json:"resourceSelector,omitempty"`
 
 	// Description is a short user friendly message for the policy rule
 	Description string `json:"message,omitempty"`

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/zz_generated.deepcopy.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/zz_generated.deepcopy.go
@@ -184,8 +184,8 @@ func (in *PolicyReportResult) DeepCopyInto(out *PolicyReportResult) {
 			}
 		}
 	}
-	if in.SubjectSelector != nil {
-		in, out := &in.SubjectSelector, &out.SubjectSelector
+	if in.ResourceSelector != nil {
+		in, out := &in.ResourceSelector, &out.ResourceSelector
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}


### PR DESCRIPTION
Fixes #96 

Update go field name to `ResourceSelector` from `SubjectSelector`