### PR TITLE
Add a top level policy engine identifier

### DIFF
--- a/policy-report/crd/v1beta1/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/policy-report/crd/v1beta1/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -875,7 +875,8 @@ spec:
                   type: string
                 source:
                   description: Source is an identifier for the policy engine that
-                    manages this report
+                    manages this report If the Source is specified at this level,
+                    it will override the Source field set at the PolicyReport level
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found

--- a/policy-report/crd/v1beta1/wgpolicyk8s.io_policyreports.yaml
+++ b/policy-report/crd/v1beta1/wgpolicyk8s.io_policyreports.yaml
@@ -872,7 +872,8 @@ spec:
                   type: string
                 source:
                   description: Source is an identifier for the policy engine that
-                    manages this report
+                    manages this report If the Source is specified at this level,
+                    it will override the Source field set at the PolicyReport level
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
@@ -978,6 +979,13 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+          source:
+            description: Source is an identifier for the policy engine that manages
+              this report Use this field if all the results are produced by a single
+              policy engine. If multiple policy engines are producing results in a
+              single PolicyReport, then use the Source field at the PolicyReportResult
+              level.
+            type: string
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:

--- a/policy-report/crd/v1beta1/wgpolicyk8s.io_policyreports.yaml
+++ b/policy-report/crd/v1beta1/wgpolicyk8s.io_policyreports.yaml
@@ -980,11 +980,11 @@ spec:
                 type: object
             type: object
           source:
-            description: Source is an identifier for the policy engine that manages
-              this report Use this field if all the results are produced by a single
-              policy engine. If multiple policy engines are producing results in a
-              single PolicyReport, then use the Source field at the PolicyReportResult
-              level.
+            description: Source is an identifier for the source e.g. a policy engine
+              that manages this report. Use this field if all the results are produced
+              by a single policy engine. If the results are produced by multiple sources
+              e.g. different engines or scanners, then use the Source field at the
+              PolicyReportResult level.
             type: string
           summary:
             description: PolicyReportSummary provides a summary of results

--- a/policy-report/docs/index.html
+++ b/policy-report/docs/index.html
@@ -174,9 +174,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-Source is an identifier for the policy engine that manages this report
+Source is an identifier for the source e.g. a policy engine that manages this report.
 Use this field if all the results are produced by a single policy engine.
-If multiple policy engines are producing results in a single PolicyReport,
+If the results are produced by multiple sources e.g. different engines or scanners,
 then use the Source field at the PolicyReportResult level.
 </td>
 </tr>

--- a/policy-report/docs/index.html
+++ b/policy-report/docs/index.html
@@ -167,6 +167,21 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Source is an identifier for the policy engine that manages this report
+Use this field if all the results are produced by a single policy engine.
+If multiple policy engines are producing results in a single PolicyReport,
+then use the Source field at the PolicyReportResult level.
+</td>
+</tr>
+<tr>
+<td>
 <code>scope</code></br>
 <em>
 Kubernetes core/v1.ObjectReference
@@ -243,6 +258,8 @@ string
 <td>
 <em>(Optional)</em>
 Source is an identifier for the policy engine that manages this report
+If the Source is specified at this level, it will override the Source
+field set at the PolicyReport level
 </td>
 </tr>
 <tr>

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/policyreport_types.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/policyreport_types.go
@@ -135,9 +135,9 @@ type PolicyReport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Source is an identifier for the policy engine that manages this report
+	// Source is an identifier for the source e.g. a policy engine that manages this report.
 	// Use this field if all the results are produced by a single policy engine.
-	// If multiple policy engines are producing results in a single PolicyReport,
+	// If the results are produced by multiple sources e.g. different engines or scanners,
 	// then use the Source field at the PolicyReportResult level.
 	// +optional
 	Source string `json:"source"`

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/policyreport_types.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/policyreport_types.go
@@ -69,6 +69,8 @@ type PolicyResultSeverity string
 type PolicyReportResult struct {
 
 	// Source is an identifier for the policy engine that manages this report
+	// If the Source is specified at this level, it will override the Source
+	// field set at the PolicyReport level
 	// +optional
 	Source string `json:"source"`
 
@@ -132,6 +134,13 @@ type PolicyReportResult struct {
 type PolicyReport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Source is an identifier for the policy engine that manages this report
+	// Use this field if all the results are produced by a single policy engine.
+	// If multiple policy engines are producing results in a single PolicyReport,
+	// then use the Source field at the PolicyReportResult level.
+	// +optional
+	Source string `json:"source"`
 
 	// Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
 	// +optional


### PR DESCRIPTION
Added an optional `Source` field at the `PolicyReport` level. Use this field if a single policy engine is responsible for producing results in a single `PolicyReport`.

Fixes #116 