### PR TITLE
chore: add source attribute to ClusterPolicyReport

### DIFF
--- a/policy-report/crd/v1beta1/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/policy-report/crd/v1beta1/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -1023,6 +1023,13 @@ spec:
                 type: object
             type: object
             x-kubernetes-map-type: atomic
+          source:
+            description: Source is an identifier for the source e.g. a policy engine
+              that manages this report. Use this field if all the results are produced
+              by a single policy engine. If the results are produced by multiple sources
+              e.g. different engines or scanners, then use the Source field at the
+              PolicyReportResult level.
+            type: string
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:

--- a/policy-report/docs/index.html
+++ b/policy-report/docs/index.html
@@ -70,6 +70,21 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Source is an identifier for the source e.g. a policy engine that manages this report.
+Use this field if all the results are produced by a single policy engine.
+If the results are produced by multiple sources e.g. different engines or scanners,
+then use the Source field at the PolicyReportResult level.
+</td>
+</tr>
+<tr>
+<td>
 <code>scope</code></br>
 <em>
 Kubernetes core/v1.ObjectReference

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/clusterpolicyreport_types.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/clusterpolicyreport_types.go
@@ -44,6 +44,13 @@ type ClusterPolicyReport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// Source is an identifier for the source e.g. a policy engine that manages this report.
+	// Use this field if all the results are produced by a single policy engine.
+	// If the results are produced by multiple sources e.g. different engines or scanners,
+	// then use the Source field at the PolicyReportResult level.
+	// +optional
+	Source string `json:"source"`
+
 	// Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
 	// +optional
 	Scope *corev1.ObjectReference `json:"scope,omitempty"`


### PR DESCRIPTION
Adds `source` attribute to `v1beta1.ClusterPolicyReport` to make it consistent with `v1beta1.PolicyReport`.