### PR TITLE
feat: add openapi-gen to doc.go

### DIFF
--- a/policy-report/pkg/api/wgpolicyk8s.io/v1alpha1/doc.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1alpha1/doc.go
@@ -17,5 +17,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the policy v1alpha1 API group
 // +k8s:deepcopy-gen=package
 // +kubebuilder:object:generate=true
+// +k8s:openapi-gen=true
 // +groupName=wgpolicyk8s.io
 package v1alpha1

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2/doc.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2/doc.go
@@ -17,5 +17,6 @@ limitations under the License.
 // Package v1alpha2 contains API Schema definitions for the policy v1alpha2 API group
 // +k8s:deepcopy-gen=package
 // +kubebuilder:object:generate=true
+// +k8s:openapi-gen=true
 // +groupName=wgpolicyk8s.io
 package v1alpha2

--- a/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/doc.go
+++ b/policy-report/pkg/api/wgpolicyk8s.io/v1beta1/doc.go
@@ -17,5 +17,6 @@ limitations under the License.
 // Package v1alpha2 contains API Schema definitions for the policy v1alpha2 API group
 // +k8s:deepcopy-gen=package
 // +kubebuilder:object:generate=true
+// +k8s:openapi-gen=true
 // +groupName=wgpolicyk8s.io
 package v1beta1


### PR DESCRIPTION
## Explaination
I tried to generate Open API Definitions for policy report types using `openapi-gen` but failed to do so. After looking at other types, it looks like this is happening because we do not have `+k8s:openapi-gen=true` in our doc.go file like other types such as metrics: https://github.com/kubernetes/metrics/blob/4cb85617e7f433b5bedfc1b120040255f6168e74/pkg/apis/metrics/v1beta1/doc.go#L20

This PR adds openapi-gen to doc.go.
