### PR TITLE
fix: update the oscal-samples demo to use the latest trestle

### DIFF
--- a/policy-report/oscal-transformer/Makefile
+++ b/policy-report/oscal-transformer/Makefile
@@ -26,7 +26,7 @@ install:
 		source venv.trestle/bin/activate; \
 		echo "=> install trestle with prereqs"; \
 		python -m pip install -q --upgrade pip setuptools; \
-		python -m pip install -q compliance-trestle==1.1.0; \
+		python -m pip install -q compliance-trestle; \
 		echo "=> create and initialize trestle workspace"; \
 		mkdir trestle.workspace; \
 		cd trestle.workspace; \
@@ -60,6 +60,7 @@ oscal.partial: install
 
 .SILENT: help
 help: install
+	source venv.trestle/bin/activate; \
 	echo ">> python k8s-to-oscal.py -h"; \
 	python k8s-to-oscal.py -h;
 


### PR DESCRIPTION
# Description
1. Resolved https://github.com/oscal-compass/compliance-trestle-demos/issues/41
2. Updated the `Makefile` to install the latest trestle version and activate the virtual environment for `make help`
3. Fixed importing the deprecated module in `k8s-to-oscal.py`
4. Created a helper function to indicate whether the YAML file is valid in `k8s-to-oscal.py`, and only parse those are valid.
